### PR TITLE
 feat(nsq): Provide a simple queue for deis infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+manifests/*.tmp.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016 Engine Yard, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+SHELL = /bin/bash
+
+DOCKER_HOST = $(shell echo $$DOCKER_HOST)
+BUILD_TAG ?= git-$(shell git rev-parse --short HEAD)
+SHORT_NAME ?= nsq
+DEIS_REGISTRY ?= ${DEV_REGISTRY}
+IMAGE_PREFIX ?= deis
+
+include versioning.mk
+
+build: docker-build
+push: docker-push
+install: kube-install
+uninstall: kube-delete
+upgrade: kube-update
+
+docker-build:
+	docker build -t ${IMAGE} rootfs
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
+
+clean: check-docker
+	docker rmi $(IMAGE)
+
+update-manifests:
+	sed 's#\(image:\) .*#\1 $(IMAGE)#' manifests/deis-nsqd-rc.yaml > manifests/deis-nsqd-rc.tmp.yaml
+
+kube-install: update-manifests
+	kubectl create -f manifests/deis-nsqd-svc.yaml
+	kubectl create -f manifests/deis-nsqd-rc.yaml
+
+kube-delete:
+	kubectl delete -f manifests/deis-nsqd-svc.yaml
+	kubectl delete -f manifests/deis-nsqd-rc.yaml
+
+kube-update: update-manifests
+	kubectl delete -f manifests/deis-nsqd-rc.tmp.yaml
+	kubectl create -f manifests/deis-nsqd-rc.tmp.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# nsq
-A kubernetes based docker image for running nsqd
+# Deis NSQ
+Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy and manage
+applications on your own servers. Deis builds on [Kubernetes](http://kubernetes.io/) to provide
+a lightweight, [Heroku-inspired](http://heroku.com) workflow.
+
+![Deis Graphic](https://s3-us-west-2.amazonaws.com/get-deis/deis-graphic-small.png)
+
+A NSQ image for running on a kubernetes cluster.
+
+## Description
+NSQ is a high performance realtime distributed messaging platform. This image is for running `nsqd` on a kubernetes cluster. It provides no data persistence or the `nsqlookupd` service. Access to the queue is provided through a service ip.
+
+## License
+© 2016 Engine Yard, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/manifests/deis-nsqd-rc.tmp.yaml
+++ b/manifests/deis-nsqd-rc.tmp.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-nsqd
+  namespace: deis
+  labels:
+    heritage: deis
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-nsqd
+  template:
+    metadata:
+      labels:
+        app: deis-nsqd
+    spec:
+      serviceAccount: deis-nsqd
+      containers:
+        - name: deis-nsqd
+          image: quay.io/jchauncey/nsq:git-c8ebe4a
+          imagePullPolicy: Always
+          command:
+          - /opt/nsq/start-nsqd
+          ports:
+          - containerPort: 4151
+            name: http
+            protocol: TCP
+          - containerPort: 4150
+            name: transport
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 4151
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 4151
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        

--- a/manifests/deis-nsqd-rc.yaml
+++ b/manifests/deis-nsqd-rc.yaml
@@ -18,10 +18,10 @@ spec:
       serviceAccount: deis-nsqd
       containers:
         - name: deis-nsqd
-          image: quay.io/jchauncey/nsq:git-c8ebe4a
+          image: quay.io/deisci/nsq:canary
           imagePullPolicy: Always
           command:
-          - /opt/nsq/start-nsqd
+          - /opt/nsq/bin/start-nsqd
           ports:
           - containerPort: 4151
             name: http
@@ -46,4 +46,3 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        

--- a/manifests/deis-nsqd-service-account.yaml
+++ b/manifests/deis-nsqd-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deis-nsqd
+  namespace: deis
+  labels:
+    heritage: deis

--- a/manifests/deis-nsqd-svc.yaml
+++ b/manifests/deis-nsqd-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-nsqd
+  namespace: deis
+  labels:
+    heritage: deis
+    app: deis-nsqd
+spec:
+  ports:
+  - port: 4151
+    name: http
+    targetPort: http
+  - port: 4150
+    name: transport
+    targetPort: transport
+  selector:
+    app: deis-nsqd

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,0 +1,18 @@
+FROM quay.io/deis/base:0.3.0
+
+RUN adduser --system \
+      --shell /bin/bash \
+      --disabled-password \
+      --home /opt/nsq \
+      --group \
+      nsq \
+    && curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > /usr/bin/jq \
+    && chmod +x /usr/bin/jq \
+    && curl -s https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.8.linux-amd64.go1.6.2.tar.gz | tar xz \
+    && mv /nsq-0.3.8.linux-amd64.go1.6.2/bin/* /bin \
+    && rm -r /nsq-0.3.8.linux-amd64.go1.6.2 \
+    && mkdir /opt/nsq/data
+
+COPY . /
+RUN chown -R nsq:nsq /opt/nsq
+USER nsq

--- a/rootfs/opt/nsq/bin/start-nsqd
+++ b/rootfs/opt/nsq/bin/start-nsqd
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export MAX_READY_COUNT=${MAX_READY_COUNT:-10000}
+export BEARER_TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token
+export DATA_PATH=${DATA_PATH:-/opt/nsq/data}
+if [ -f $BEARER_TOKEN ]; then
+    export TOKEN=$(cat $BEARER_TOKEN)
+    export POD_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/namespaces/$POD_NAMESPACE/pods/$HOSTNAME
+    export NODE_NAME=$(curl -s $POD_API_URL --header "Authorization: Bearer $TOKEN" --insecure | grep nodeName | cut -c 18- | tr -d '",')
+    echo "Set broadcast-address to ${NODE_NAME} and MAX_READY_COUNT to ${MAX_READY_COUNT}"
+    exec nsqd -broadcast-address ${NODE_NAME} -max-rdy-count ${MAX_READY_COUNT} --data-path ${DATA_PATH}
+else
+  echo "Need a bearer token to start nsqd. Please create a service account."
+  exit 1
+fi

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,0 +1,22 @@
+MUTABLE_VERSION ?= canary
+VERSION ?= git-$(shell git rev-parse --short HEAD)
+
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+MUTABLE_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
+
+info:
+	@echo "Build tag:       ${VERSION}"
+	@echo "Registry:        ${DEIS_REGISTRY}"
+	@echo "Immutable tag:   ${IMAGE}"
+	@echo "Mutable tag:     ${MUTABLE_IMAGE}"
+
+.PHONY: docker-push
+docker-push: docker-mutable-push docker-immutable-push
+
+.PHONY: docker-immutable-push
+docker-immutable-push:
+	docker push ${IMAGE}
+
+.PHONY: docker-mutable-push
+docker-mutable-push:
+	docker push ${MUTABLE_IMAGE}


### PR DESCRIPTION
The nsq instance is run as a replication controller. 
It contains no logic for discovering other nsq instances or an nsqlookupd instance.
There is also no data persistence.
