### PR TITLE
Adding set -e to start up script

### DIFF
--- a/rootfs/opt/nsq/bin/start-nsqd
+++ b/rootfs/opt/nsq/bin/start-nsqd
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 export MAX_READY_COUNT=${MAX_READY_COUNT:-10000}
 export BEARER_TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Without the the `set -e` errors parsing the node address from the api will not be caught.
